### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -47,6 +47,13 @@ description: |-
   atmos terraform deploy snowflake/account --stack $TENANT-use2-sbx01
   ```
 
+  ## Migrate `chanzuckerberg/snowflake` to `snowflakedb/snowflake` provider
+  5/25/2022 the provider has been transferred from the Chan Zuckerberg Initiative (CZI) GitHub organization to snowflakedb org.
+  To upgrade from CZI, please run the following command:
+  ```shell
+  terraform state replace-provider chanzuckerberg/snowflake snowflakedb/snowflake
+  ```
+
   ## Usage
 
   **Stack Level**: Regional

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.0, < 6.0.0"
     }
     snowflake = {
       source  = "chanzuckerberg/snowflake"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 3.0, < 6.0.0"
     }
     snowflake = {
-      source  = "chanzuckerberg/snowflake"
+      source  = "snowflakedb/snowflake"
       version = ">= 0.25"
     }
     tls = {


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

* `src/versions.tf`: Updated the version constraint for the `aws` provider to `>= 4.9.0, < 6.0.0` to ensure compatibility with future versions while avoiding potential breaking changes in version 6.0.0.
* `src/versions.tf`: Migrate `chanzuckerberg/snowflake` to `snowflakedb/snowflake` provider. 
Please read this migration guide if you are using `chanzuclerberg/snowflake` https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/CZI_UPGRADE.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to reflect the new Snowflake Terraform provider namespace and included guidance for migrating existing state references.

* **Chores**
  * Updated AWS provider version constraints to limit compatibility to versions below 6.0.0.
  * Changed the Snowflake provider source to the new official namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->