### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/introspection.mixin.tf
+++ b/src/introspection.mixin.tf
@@ -3,7 +3,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   check_required_tags = module.this.enabled ? [
     for k in var.required_tags :
-    lookup(module.this.tags, k)
+    module.this.tags[k]
   ] : []
 }
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -29,7 +29,7 @@ module "snowflake_account" {
   version = "0.25.0"
 
   # Change to use the Snowflake region, typically the same as the given stack
-  environment = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+  environment = module.utils.region_az_alt_code_maps["to_short"][var.snowflake_account_region]
 
   context = module.introspection.context
 }
@@ -40,7 +40,7 @@ module "snowflake_warehouse" {
   version = "0.25.0"
 
   # Change to use the Snowflake region, typically the same as the given stack
-  environment = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+  environment = module.utils.region_az_alt_code_maps["to_short"][var.snowflake_account_region]
 
   attributes = ["default", "wh"]
 
@@ -104,7 +104,7 @@ module "snowflake_role" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  environment      = lookup(module.utils.region_az_alt_code_maps["to_short"], var.snowflake_account_region)
+  environment      = module.utils.region_az_alt_code_maps["to_short"][var.snowflake_account_region]
   attributes       = ["terraform", "role"]
   delimiter        = ""
   label_value_case = "title"
@@ -128,7 +128,7 @@ resource "snowflake_role_grants" "grant_system_roles" {
   # Snowflake resource names are enclosed in quotes intentionally per Idenitier Requirements:
   # https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#identifier-requirements
   roles = [
-    "${snowflake_role.terraform[0].name}",
+    snowflake_role.terraform[0].name,
   ]
 }
 
@@ -140,7 +140,7 @@ resource "snowflake_role_grants" "grant_custom_roles" {
   # Snowflake resource names are enclosed in quotes intentionally per Idenitier Requirements:
   # https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#identifier-requirements
   users = [
-    "${snowflake_user.terraform[0].name}",
+    snowflake_user.terraform[0].name,
   ]
 }
 


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)